### PR TITLE
Add API documentation and detailed docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ ChromaRAG/
 3. **Access the API**:
     - The API will be available at `http://localhost:8000`.
     - Swagger UI is available at `http://localhost:8000/docs`.
+    - Additional endpoint documentation can be found in [docs/API.md](docs/API.md).
 
 ## Authentication
 

--- a/app/chroma_client.py
+++ b/app/chroma_client.py
@@ -1,7 +1,10 @@
+"""Utility for creating and reusing the ChromaDB client."""
+
 import chromadb
 
 # Initialize the ChromaDB Persistent Client
 client = chromadb.PersistentClient(path="/data/chromadb")
 
-def get_client():
+def get_client() -> chromadb.PersistentClient:
+    """Return the shared :class:`chromadb.PersistentClient` instance."""
     return client

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,3 +1,5 @@
+"""Dependency utilities for API key authentication and role checking."""
+
 from fastapi import Depends, HTTPException, Security
 from fastapi.security.api_key import APIKeyHeader
 from starlette.status import HTTP_403_FORBIDDEN
@@ -12,7 +14,8 @@ USER_ROLES = {
     "another-api-key": "user"        # Regular user role
 }
 
-def get_api_key(api_key_header: str = Security(api_key_header)):
+def get_api_key(api_key_header: str = Security(api_key_header)) -> str:
+    """Validate the provided API key and return it if valid."""
     if api_key_header in USER_ROLES:
         return api_key_header
     else:
@@ -21,10 +24,13 @@ def get_api_key(api_key_header: str = Security(api_key_header)):
         )
 
 def has_role(required_role: str):
+    """Return a dependency that ensures the authenticated user has ``required_role``."""
+
     def role_checker(api_key: str = Depends(get_api_key)):
         user_role = USER_ROLES.get(api_key)
         if user_role != required_role:
             raise HTTPException(
                 status_code=HTTP_403_FORBIDDEN, detail="Insufficient permissions"
             )
+
     return role_checker

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,10 @@
+"""Application entry point for the FastAPI server.
+
+This module creates the :class:`FastAPI` instance, adds middleware and includes
+all API routers. Import ``app`` from this module when running with Uvicorn or
+for testing.
+"""
+
 from fastapi import FastAPI, Depends
 from routers import collections, documents
 from dependencies import get_api_key

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -1,9 +1,13 @@
+"""Middleware components used by the FastAPI application."""
+
 from fastapi import FastAPI, Request, HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.status import HTTP_429_TOO_MANY_REQUESTS
 import time
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Simple in-memory IP based rate limiting middleware."""
+
     def __init__(self, app: FastAPI, max_requests: int, time_window: int):
         super().__init__(app)
         self.max_requests = max_requests
@@ -11,6 +15,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self.request_counts = {}
 
     async def dispatch(self, request: Request, call_next):
+        """Process each request and enforce rate limits."""
         client_ip = request.client.host
         current_time = time.time()
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,8 +1,11 @@
+"""Pydantic models used by the API."""
+
 from pydantic import BaseModel, Field, HttpUrl, conlist
 from typing import List, Dict, Optional
 import numpy as np
 
 class Document(BaseModel):
+    """Represents a single item that can be stored in ChromaDB."""
     id: str = Field(..., description="Unique identifier for the document")
     text: Optional[str] = Field(None, description="Text content of the document")
     metadata: Optional[Dict] = Field(None, description="Additional metadata")
@@ -13,6 +16,7 @@ class Document(BaseModel):
     uri: Optional[HttpUrl] = Field(None, description="Valid URI to the external data source")
 
 class Query(BaseModel):
+    """Query parameters used when searching a collection."""
     query_texts: Optional[List[str]] = Field(None, description="List of query texts")
     query_embeddings: Optional[List[conlist(float, min_items=128, max_items=128)]] = Field(
         None, description="List of embedding vectors, each of length 128"

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,1 +1,1 @@
-# routers/__init__.py
+"""Package containing the API routers."""

--- a/app/routers/collections.py
+++ b/app/routers/collections.py
@@ -1,22 +1,24 @@
+"""Endpoints for managing ChromaDB collections."""
+
 from fastapi import APIRouter, HTTPException
 from typing import Optional
 from chroma_client import get_client
 
 router = APIRouter()
 
-# Create a collection
 @router.post("/create_collection")
 async def create_collection(name: str, embedding_function: Optional[str] = None):
+    """Create a new collection."""
     try:
         client = get_client()
-        collection = client.create_collection(name=name, embedding_function=embedding_function)
+        client.create_collection(name=name, embedding_function=embedding_function)
         return {"message": f"Collection {name} created successfully."}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-# Delete a collection
 @router.delete("/delete_collection/{collection_name}")
 async def delete_collection(collection_name: str):
+    """Remove an existing collection."""
     try:
         client = get_client()
         client.delete_collection(name=collection_name)

--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -1,3 +1,5 @@
+"""Endpoints for managing documents within collections."""
+
 from fastapi import APIRouter, HTTPException, BackgroundTasks
 from typing import List
 from chroma_client import get_client
@@ -14,7 +16,8 @@ from datetime import datetime
 # Configure the logging
 logging.basicConfig(filename='audit.log', level=logging.INFO)
 
-def log_access(user: str, action: str, document_id: str):
+def log_access(user: str, action: str, document_id: str) -> None:
+    """Write an audit log entry for document operations."""
     logging.info(f"{datetime.utcnow()} - {user} performed {action} on document ID {document_id}")
 
 router = APIRouter()
@@ -24,13 +27,15 @@ router = APIRouter()
 async def add_documents_background(
     collection_name: str, documents: List[Document], background_tasks: BackgroundTasks
 ):
+    """Schedule a background task to add documents to a collection."""
     background_tasks.add_task(add_documents_task, collection_name, documents)
     return {"message": "Documents are being added in the background."}
 
 async def add_documents_task(collection_name: str, documents: List[Document]):
+    """Background worker that inserts documents into ``collection_name``."""
     client = get_client()
     collection = client.get_or_create_collection(name=collection_name)
-    
+
     # Ensure that every field list has the same length as ``documents`` to
     # avoid errors in ChromaDB operations.
     fields = build_chroma_fields(documents)
@@ -39,13 +44,14 @@ async def add_documents_task(collection_name: str, documents: List[Document]):
 # Add documents to a collection (supports multimodal)
 @router.post("/add_documents/{collection_name}")
 async def add_documents(collection_name: str, documents: List[Document]):
+    """Synchronously add documents to a multimodal collection."""
     try:
         client = get_client()
         embedding_function = get_openclip_embedding_function()
         data_loader = get_image_loader()
         collection = client.get_or_create_collection(
-            name=collection_name, 
-            embedding_function=embedding_function, 
+            name=collection_name,
+            embedding_function=embedding_function,
             data_loader=data_loader
         )
 
@@ -59,6 +65,7 @@ async def add_documents(collection_name: str, documents: List[Document]):
 # Query the collection (supports multimodal)
 @router.post("/query_collection/{collection_name}")
 async def query_collection(collection_name: str, query: Query):
+    """Search a collection using text, embeddings, images or URIs."""
     try:
         client = get_client()
         collection = client.get_collection(name=collection_name)
@@ -70,12 +77,12 @@ async def query_collection(collection_name: str, query: Query):
             n_results=query.n_results,
             where=query.where,
             where_document=query.where_document,
-            include=["documents", "metadatas", "embeddings", "distances"]  # Customize this as needed
+            include=["documents", "metadatas", "embeddings", "distances"]
         )
 
         # Decrypt the metadata before returning
         decrypted_metadata = [
-            decrypt_data(metadata) 
+            decrypt_data(metadata)
             for metadata in results['metadatas']
         ]
         results['metadatas'] = decrypted_metadata
@@ -87,6 +94,7 @@ async def query_collection(collection_name: str, query: Query):
 # Update documents in a collection with consistency check (supports multimodal)
 @router.put("/update_documents/{collection_name}")
 async def update_documents(collection_name: str, documents: List[Document]):
+    """Update existing documents, ensuring each ID already exists."""
     try:
         client = get_client()
         collection = client.get_collection(name=collection_name)

--- a/app/security.py
+++ b/app/security.py
@@ -1,3 +1,5 @@
+"""Encryption and anonymization helpers used for compliance."""
+
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.backends import default_backend
@@ -8,16 +10,19 @@ cipher_suite = Fernet(key)
 
 # Function to encrypt sensitive data
 def encrypt_data(data: str) -> str:
-    encrypted_data = cipher_suite.encrypt(data.encode('utf-8'))
-    return encrypted_data.decode('utf-8')
+    """Encrypt ``data`` using Fernet."""
+    encrypted_data = cipher_suite.encrypt(data.encode("utf-8"))
+    return encrypted_data.decode("utf-8")
 
 # Function to decrypt sensitive data
 def decrypt_data(encrypted_data: str) -> str:
-    decrypted_data = cipher_suite.decrypt(encrypted_data.encode('utf-8'))
-    return decrypted_data.decode('utf-8')
+    """Decrypt data previously encrypted with :func:`encrypt_data`."""
+    decrypted_data = cipher_suite.decrypt(encrypted_data.encode("utf-8"))
+    return decrypted_data.decode("utf-8")
 
 # Function to anonymize sensitive data by hashing it
 def anonymize_data(data: str) -> str:
+    """Return a SHA-256 hash of ``data`` for anonymization."""
     digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
-    digest.update(data.encode('utf-8'))
+    digest.update(data.encode("utf-8"))
     return digest.finalize().hex()

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,3 +1,5 @@
+"""Helper utilities used across the API."""
+
 from chromadb.utils.embedding_functions import OpenCLIPEmbeddingFunction
 from chromadb.utils.data_loaders import ImageLoader
 from typing import List, Dict
@@ -5,11 +7,13 @@ from models import Document
 from security import encrypt_data
 
 # Initialize the OpenCLIP embedding function
-def get_openclip_embedding_function():
+def get_openclip_embedding_function() -> OpenCLIPEmbeddingFunction:
+    """Return the default OpenCLIP embedding function."""
     return OpenCLIPEmbeddingFunction()
 
 # Initialize the ImageLoader for multimodal collections
-def get_image_loader():
+def get_image_loader() -> ImageLoader:
+    """Return the default image loader for multimodal content."""
     return ImageLoader()
 
 # Build lists of document fields for ChromaDB operations. This helper ensures

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,127 @@
+# API Documentation
+
+This document describes the public REST API endpoints and utility functions available in **ChromaRAG**. The API is served using FastAPI and is secured using API key authentication.
+
+## Authentication
+
+All endpoints require a valid API key. Include the key in the `Authorization` header:
+
+```bash
+curl -H "Authorization: Bearer your-secure-api-key" http://localhost:8000
+```
+
+## Endpoints
+
+### Collections
+
+#### `POST /collections/create_collection`
+Create a new ChromaDB collection.
+
+**Parameters**
+- `name` (*str*, required) – Name of the collection.
+- `embedding_function` (*str*, optional) – Name of the embedding function to use.
+
+**Example**
+```bash
+curl -X POST \
+  -H "Authorization: Bearer your-secure-api-key" \
+  -d "name=my_collection" \
+  http://localhost:8000/collections/create_collection
+```
+
+#### `DELETE /collections/delete_collection/{collection_name}`
+Delete an existing collection by name.
+
+**Example**
+```bash
+curl -X DELETE \
+  -H "Authorization: Bearer your-secure-api-key" \
+  http://localhost:8000/collections/delete_collection/my_collection
+```
+
+### Documents
+
+#### `POST /documents/add_documents_background/{collection_name}`
+Add documents to a collection using a background task.
+
+Body payload is a JSON array of `Document` objects.
+
+**Example**
+```bash
+curl -X POST \
+  -H "Authorization: Bearer your-secure-api-key" \
+  -H "Content-Type: application/json" \
+  -d '[{"id": "doc1", "text": "hello"}]' \
+  http://localhost:8000/documents/add_documents_background/my_collection
+```
+
+#### `POST /documents/add_documents/{collection_name}`
+Add documents to a multimodal collection synchronously.
+
+Body payload is a JSON array of `Document` objects.
+
+#### `POST /documents/query_collection/{collection_name}`
+Query a collection using text, embeddings, images or URIs.
+
+Body payload is a `Query` object.
+
+#### `PUT /documents/update_documents/{collection_name}`
+Update existing documents in a collection. The body payload is a JSON array of `Document` objects. Document IDs must already exist.
+
+## Data Models
+
+### `Document`
+```json
+{
+  "id": "unique-id",
+  "text": "optional text",
+  "metadata": {"key": "value"},
+  "embedding": [0.0, 0.1, ...],
+  "image": null,
+  "uri": null
+}
+```
+
+### `Query`
+```json
+{
+  "query_texts": ["search term"],
+  "query_embeddings": [[0.0, 0.1, ...]],
+  "query_images": null,
+  "query_uris": null,
+  "n_results": 10,
+  "where": null,
+  "where_document": null
+}
+```
+
+## Utility Functions
+
+The project exposes helper functions that can be imported for programmatic use:
+
+- `get_openclip_embedding_function()` – returns an OpenCLIP embedding function instance.
+- `get_image_loader()` – returns an image loader for multimodal inputs.
+- `build_chroma_fields(documents)` – converts a list of `Document` models into field lists for ChromaDB operations.
+- `encrypt_data(data)` / `decrypt_data(data)` – utilities for encrypting and decrypting strings.
+- `anonymize_data(data)` – one-way hashing of sensitive values.
+
+## Usage Example
+
+Below is a small Python example that creates a collection and inserts a document:
+
+```python
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+headers = {"Authorization": "Bearer your-secure-api-key"}
+
+# Create the collection
+client.post("/collections/create_collection", params={"name": "demo"}, headers=headers)
+
+# Add a document
+payload = [{"id": "doc1", "text": "hello world"}]
+client.post("/documents/add_documents/demo", json=payload, headers=headers)
+```
+
+This example uses `TestClient` for convenience but any HTTP client can be used.


### PR DESCRIPTION
## Summary
- document all FastAPI endpoints and utilities in `docs/API.md`
- link the new docs from `README.md`
- add descriptive docstrings across the codebase

## Testing
- `python -m compileall -q app`

------
https://chatgpt.com/codex/tasks/task_e_6864b80f29dc8333b0e5e80682816c92