### PR TITLE
Harden metadata enrichment and pgvector backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ I will be seeking to ensure that ChromaRAG complies with GDPR, HIPAA, and SOC 2 
 - **Consistency Checks**: Verifies data consistency before updates or deletes.
 - **Background Processing**: Offloads time-consuming tasks to background processes.
 - **Rate Limiting**: Prevents overloading the API with excessive requests.
+- **Vector Backups in Postgres**: Mirrors documents, metadata labels, and embeddings inside a pgvector-enabled Postgres database for recovery and analytics workflows.
 - **Compliance**: Implements data encryption, anonymization, and access controls for GDPR, HIPAA, and SOC 2 compliance.
 
 ## Folder Structure
@@ -56,6 +57,7 @@ ChromaRAG/
     ```bash
     docker-compose up --build
     ```
+    This starts FastAPI, ChromaDB, and a pgvector-enabled Postgres instance for embedding backups. The FastAPI container automatically persists documents and embeddings into both ChromaDB and Postgres when `POSTGRES_URL` is provided.
 
 3. **Access the API**:
     - The API will be available at `http://localhost:8000`.
@@ -85,6 +87,40 @@ curl -H "Authorization: Bearer your-secure-api-key" http://localhost:8000/your-e
 ## Data Encryption
 
 Sensitive data is encrypted and anonymized using the cryptography library to ensure data protection. Refer to `app/security.py` for implementation details.
+
+## Render Deployment
+
+Deploy the full stack on Render using the provided [`render.yaml`](render.yaml) blueprint:
+
+```bash
+render blueprint deploy render.yaml
+```
+
+The blueprint provisions:
+
+- A FastAPI web service built from this repository's Dockerfile.
+- A private Chromadb service with persistent disk storage.
+- A managed Postgres instance with the pgvector extension for embedding backups.
+
+## Kubernetes Deployment
+
+The [`k8s/`](k8s) directory contains manifests for a production-style cluster deployment:
+
+1. Create secrets for Postgres credentials by copying and editing `k8s/secrets.example.yaml` before applying manifests.
+2. Apply the namespace, config maps, secrets, and workloads:
+
+    ```bash
+    kubectl apply -f k8s/namespace.yaml
+    kubectl apply -f k8s/secrets.yaml   # your customized secret file
+    kubectl apply -f k8s/configmap.yaml
+    kubectl apply -f k8s/postgres.yaml
+    kubectl apply -f k8s/chromadb.yaml
+    kubectl apply -f k8s/api.yaml
+    ```
+
+3. Build and push the FastAPI container image referenced in `k8s/api.yaml` (replace `your-registry/chromarag:latest` with your published image).
+
+The deployment keeps embeddings synchronized across ChromaDB and Postgres through the application's startup hooks and request handlers.
 
 ## Contributing
 

--- a/app/chroma_client.py
+++ b/app/chroma_client.py
@@ -1,10 +1,44 @@
 """Utility for creating and reusing the ChromaDB client."""
 
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Optional
+from urllib.parse import urlparse
+
 import chromadb
 
-# Initialize the ChromaDB Persistent Client
-client = chromadb.PersistentClient(path="./data/chromadb")
 
-def get_client() -> chromadb.PersistentClient:
-    """Return the shared :class:`chromadb.PersistentClient` instance."""
-    return client
+def _build_http_client(database_url: str) -> chromadb.ClientAPI:
+    """Return an :class:`chromadb.HttpClient` configured for ``database_url``."""
+
+    parsed = urlparse(database_url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(
+            "DATABASE_URL must be an HTTP(S) URL when provided."
+        )
+
+    host = parsed.hostname or "localhost"
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    ssl = parsed.scheme == "https"
+
+    return chromadb.HttpClient(host=host, port=port, ssl=ssl)
+
+
+def _build_persistent_client(path: Optional[str] = None) -> chromadb.PersistentClient:
+    """Return a :class:`chromadb.PersistentClient` for local persistence."""
+
+    client_path = path or os.getenv("CHROMA_PERSIST_PATH", "./data/chromadb")
+    return chromadb.PersistentClient(path=client_path)
+
+
+@lru_cache(maxsize=1)
+def get_client() -> chromadb.ClientAPI:
+    """Return a shared ChromaDB client instance."""
+
+    database_url = os.getenv("DATABASE_URL")
+    if database_url:
+        return _build_http_client(database_url)
+
+    return _build_persistent_client()

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.routers import collections, documents
 from app.dependencies import get_api_key
 from app.middleware import RateLimitMiddleware
+from app.postgres_store import init_db
 
 # Initialize the FastAPI app
 app = FastAPI()
@@ -24,6 +25,13 @@ app.add_middleware(
 )
 
 app.add_middleware(RateLimitMiddleware, max_request=10, time_window=60)
+
+
+@app.on_event("startup")
+def startup_event() -> None:
+    """Initialise backing services when the API boots."""
+
+    init_db()
 
 # Include the routers with API key dependency
 app.include_router(collections.router, prefix="/collections", tags=["Collections"], dependencies=[Depends(get_api_key)])

--- a/app/metadata_enrichment.py
+++ b/app/metadata_enrichment.py
@@ -1,0 +1,313 @@
+"""Utilities for enriching document metadata prior to persistence."""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+import re
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+import requests
+from pypdf import PdfReader
+
+from app.models import Document
+
+_LOGGER = logging.getLogger(__name__)
+
+_STOPWORDS = {
+    "the",
+    "and",
+    "for",
+    "that",
+    "with",
+    "this",
+    "from",
+    "have",
+    "your",
+    "into",
+    "about",
+    "there",
+    "their",
+    "will",
+    "which",
+    "while",
+    "where",
+    "been",
+    "being",
+    "over",
+    "also",
+    "such",
+    "through",
+    "shall",
+    "should",
+    "would",
+    "could",
+    "here",
+    "when",
+    "than",
+    "then",
+    "them",
+    "they",
+    "because",
+    "between",
+    "after",
+    "before",
+    "other",
+    "more",
+    "only",
+    "those",
+    "these",
+    "into",
+    "upon",
+}
+
+_REQUIRED_FIELDS = {"title", "summary", "topics", "keywords"}
+
+
+def _has_value(value: Any) -> bool:
+    """Return ``True`` when ``value`` should be considered populated."""
+
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, set, dict)):
+        return bool(value)
+    return bool(value)
+
+
+def _generate_title(text: str) -> Optional[str]:
+    """Create a fallback title when PDF metadata does not supply one."""
+
+    sentences = re.split(r"(?<=[.!?])\s+", text.strip())
+    for sentence in sentences:
+        if sentence:
+            return sentence[:120].strip()
+    words = text.strip().split()
+    if not words:
+        return None
+    return " ".join(words[:8]).strip()
+
+
+@dataclass
+class EnrichmentResult:
+    """Structured response from the enrichment pipeline."""
+
+    metadata: Dict[str, Any]
+    evidence: Iterable[str]
+
+
+def is_metadata_complete(metadata: Optional[Dict[str, Any]]) -> bool:
+    """Return ``True`` when metadata already contains the expected keys."""
+
+    if not metadata:
+        return False
+    populated = {key for key, value in metadata.items() if _has_value(value)}
+    return _REQUIRED_FIELDS.issubset(populated)
+
+
+def enrich_metadata(document: Document) -> Dict[str, Any]:
+    """Populate missing metadata fields by inspecting the PDF/text content."""
+
+    metadata: Dict[str, Any] = dict(document.metadata or {})
+
+    pdf_details = _extract_pdf_metadata(document, metadata)
+    metadata.update({k: v for k, v in pdf_details.items() if _has_value(v)})
+
+    text_content = document.text or pdf_details.get("sample_text") or ""
+    if text_content and not _has_value(metadata.get("title")):
+        fallback_title = _generate_title(text_content)
+        if fallback_title:
+            metadata["title"] = fallback_title
+    nlp_details = _extract_nlp_features(text_content)
+
+    for key, value in nlp_details.metadata.items():
+        if not _has_value(metadata.get(key)) and _has_value(value):
+            metadata[key] = value
+
+    existing_evidence = metadata.get("evidence") or []
+    if not isinstance(existing_evidence, list):
+        existing_evidence = [existing_evidence]
+    evidence = list(dict.fromkeys([*existing_evidence, *nlp_details.evidence]))
+    if evidence:
+        metadata["evidence"] = evidence
+
+    llm_enrichment = _call_llm(metadata, text_content)
+    for key, value in llm_enrichment.items():
+        if _has_value(value) and not _has_value(metadata.get(key)):
+            metadata[key] = value
+
+    return metadata
+
+
+def _extract_pdf_metadata(document: Document, metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """Read intrinsic PDF metadata when the document references a PDF."""
+
+    source_path = metadata.get("file_path") or metadata.get("local_path")
+    reader: Optional[PdfReader] = None
+    sample_text: Optional[str] = None
+
+    if source_path:
+        path = Path(source_path)
+        if path.exists() and path.suffix.lower() == ".pdf":
+            reader = PdfReader(str(path))
+    elif document.uri and str(document.uri).lower().endswith(".pdf"):
+        uri = str(document.uri)
+        try:
+            response = requests.get(uri, timeout=10)
+            response.raise_for_status()
+            reader = PdfReader(io.BytesIO(response.content))
+        except Exception as exc:  # pragma: no cover - network failures are logged
+            _LOGGER.warning("Failed to download PDF from %s: %s", uri, exc)
+
+    if reader is None:
+        return {}
+
+    info = reader.metadata or {}
+    details: Dict[str, Any] = {}
+
+    title = getattr(info, "title", None) or info.get("/Title")
+    author = getattr(info, "author", None) or info.get("/Author")
+    subject = getattr(info, "subject", None) or info.get("/Subject")
+    creation_date = getattr(info, "creation_date", None) or info.get("/CreationDate")
+
+    if title:
+        details["title"] = title.strip()
+    if author:
+        details["author"] = author.strip()
+    if subject:
+        details["subject"] = subject.strip()
+    if creation_date:
+        details["created_at"] = _normalise_pdf_date(creation_date)
+
+    try:
+        details["page_count"] = len(reader.pages)
+    except Exception:  # pragma: no cover - defensive only
+        pass
+
+    try:
+        if reader.pages:
+            sample_text = (reader.pages[0].extract_text() or "").strip()
+    except Exception:  # pragma: no cover - extract_text can fail for some PDFs
+        sample_text = None
+
+    if sample_text:
+        details["sample_text"] = sample_text
+
+    return details
+
+
+def _normalise_pdf_date(raw_value: Any) -> Optional[str]:
+    """Convert PDF date formats to ISO-8601 strings."""
+
+    if isinstance(raw_value, datetime):
+        return raw_value.isoformat()
+
+    if isinstance(raw_value, str):
+        value = raw_value.strip()
+        # PDF dates are commonly formatted as D:YYYYMMDDHHmmSSOHH'mm'
+        match = re.match(r"D:(\d{4})(\d{2})?(\d{2})?(\d{2})?(\d{2})?(\d{2})?", value)
+        if match:
+            year, month, day, hour, minute, second = match.groups(default="01")
+            try:
+                parsed = datetime(
+                    int(year), int(month), int(day), int(hour), int(minute), int(second)
+                )
+                return parsed.isoformat()
+            except ValueError:
+                pass
+        try:
+            parsed = datetime.fromisoformat(value)
+            return parsed.isoformat()
+        except ValueError:
+            return value
+    return None
+
+
+def _extract_nlp_features(text: str) -> EnrichmentResult:
+    """Derive keywords, topics, and summaries from the document text."""
+
+    if not text:
+        return EnrichmentResult(metadata={}, evidence=[])
+
+    tokens = re.findall(r"[A-Za-z][A-Za-z'-]+", text.lower())
+    filtered_tokens = [token for token in tokens if token not in _STOPWORDS]
+    counts = Counter(filtered_tokens)
+
+    keywords = [token for token, _ in counts.most_common(5)]
+    topics = keywords[:3]
+
+    sentences = re.split(r"(?<=[.!?])\s+", text.strip())
+    evidence = [sentence.strip() for sentence in sentences[:3] if sentence.strip()]
+    summary = " ".join(evidence[:2]).strip()
+
+    metadata = {}
+    if summary:
+        metadata["summary"] = summary
+    if topics:
+        metadata["topics"] = topics
+    if keywords:
+        metadata["keywords"] = keywords
+
+    return EnrichmentResult(metadata=metadata, evidence=evidence)
+
+
+def _call_llm(metadata: Dict[str, Any], text: str) -> Dict[str, Any]:
+    """Optionally call an LLM to enrich metadata when configured."""
+
+    api_key = os.getenv("METADATA_LLM_API_KEY") or os.getenv("OPENAI_API_KEY")
+    model = os.getenv("METADATA_LLM_MODEL", "gpt-4o-mini")
+
+    if not api_key or not text:
+        return {}
+
+    try:
+        from openai import OpenAI  # type: ignore
+    except ImportError:  # pragma: no cover - optional dependency
+        _LOGGER.info("openai package not installed; skipping LLM enrichment")
+        return {}
+
+    client = OpenAI(api_key=api_key)
+    prompt = (
+        "You are assisting with document metadata enrichment. Given the following text "
+        "and existing metadata, provide a concise JSON object with optional keys "
+        "'summary', 'topics', 'keywords', and 'labels'. Ensure the response is strictly "
+        "valid JSON.\n\nMetadata: "
+        f"{json.dumps(metadata, ensure_ascii=False)}\n\nText snippet:\n{text[:4000]}"
+    )
+
+    try:
+        response = client.responses.create(
+            model=model,
+            input=[{"role": "user", "content": prompt}],
+            temperature=0,
+        )
+    except Exception as exc:  # pragma: no cover - network failures are logged
+        _LOGGER.warning("LLM enrichment failed: %s", exc)
+        return {}
+
+    try:
+        content = response.output[0].content[0].text  # type: ignore[attr-defined]
+    except Exception:  # pragma: no cover - shape differences across SDK versions
+        try:
+            content = response.output_text  # type: ignore[attr-defined]
+        except Exception:
+            _LOGGER.warning("LLM response format unexpected; skipping enrichment")
+            return {}
+
+    try:
+        parsed = json.loads(content)
+        if isinstance(parsed, dict):
+            return parsed
+    except json.JSONDecodeError:
+        _LOGGER.warning("LLM returned non-JSON content; skipping enrichment")
+    return {}
+
+
+__all__ = ["enrich_metadata", "is_metadata_complete"]

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field, HttpUrl
-from typing import List, Dict, Optional, Annotated
+from typing import Dict, List, Optional
 import numpy as np
 
 class Document(BaseModel):
@@ -15,9 +15,9 @@ class Document(BaseModel):
     uri: Optional[HttpUrl] = Field(None, description="Valid URI to the external data source")
 
 class Query(BaseModel):
- j    model_config = {"arbitrary_types_allowed": True}
-    
     """Query parameters used when searching a collection."""
+
+    model_config = {"arbitrary_types_allowed": True}
     query_texts: Optional[List[str]] = Field(None, description="List of query texts")
     query_embeddings: Optional[List[List[float]]] = Field(
         None, description="List of embedding vectors"
@@ -26,4 +26,6 @@ class Query(BaseModel):
     query_uris: Optional[List[HttpUrl]] = Field(None, description="List of valid URIs to external data sources")
     n_results: int = Field(10, description="Number of results to return")
     where: Optional[Dict] = Field(None, description="Filter conditions based on metadata")
-    where_document: Optional[Dict] = Field(None, description="Filter conditions based on document content")
+    where_document: Optional[Dict] = Field(
+        None, description="Filter conditions based on document content"
+    )

--- a/app/postgres_store.py
+++ b/app/postgres_store.py
@@ -1,0 +1,193 @@
+"""Persistence layer for storing processed documents and embeddings in Postgres."""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import contextmanager
+from typing import Iterable, Iterator, Optional
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    String,
+    Text,
+    create_engine,
+    delete,
+    func,
+    text as sql_text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
+from pgvector.sqlalchemy import Vector
+
+from app.models import Document
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _determine_embedding_dimension() -> int:
+    """Return the configured embedding dimension, defaulting sensibly."""
+
+    value = os.getenv("EMBEDDING_DIM")
+    if value:
+        try:
+            dimension = int(value)
+            if dimension > 0:
+                return dimension
+            _LOGGER.warning(
+                "EMBEDDING_DIM must be positive; received %s. Falling back to 1536.",
+                value,
+            )
+        except ValueError:
+            _LOGGER.warning(
+                "Invalid EMBEDDING_DIM value '%s'; falling back to 1536.", value
+            )
+    return 1536
+
+
+EMBEDDING_DIMENSION = _determine_embedding_dimension()
+
+Base = declarative_base()
+
+
+class ProcessedDocument(Base):
+    """ORM model storing pre-processed data and embedding backups."""
+
+    __tablename__ = "processed_documents"
+
+    id = Column(String, primary_key=True)
+    collection_name = Column(String, nullable=False, index=True)
+    text = Column(Text, nullable=True)
+    preprocessed_text = Column(Text, nullable=True)
+    metadata = Column(JSONB, nullable=True)
+    metadata_labels = Column(JSONB, nullable=True)
+    embedding = Column(Vector(EMBEDDING_DIMENSION), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+
+_ENGINE = None
+_SESSION_FACTORY: Optional[sessionmaker] = None
+_INITIALISED = False
+
+
+def _get_database_url() -> Optional[str]:
+    return os.getenv("POSTGRES_URL")
+
+
+def _get_engine():
+    global _ENGINE, _SESSION_FACTORY
+    if _ENGINE is not None:
+        return _ENGINE
+
+    database_url = _get_database_url()
+    if not database_url:
+        _LOGGER.info("POSTGRES_URL is not set; Postgres persistence disabled.")
+        return None
+
+    _ENGINE = create_engine(database_url, pool_pre_ping=True, future=True)
+    _SESSION_FACTORY = sessionmaker(bind=_ENGINE, autoflush=False, future=True)
+    return _ENGINE
+
+
+def init_db() -> None:
+    """Initialise the Postgres schema and pgvector extension if configured."""
+
+    global _INITIALISED
+    if _INITIALISED:
+        return
+
+    engine = _get_engine()
+    if engine is None:
+        return
+
+    try:
+        with engine.begin() as connection:
+            connection.execute(sql_text("CREATE EXTENSION IF NOT EXISTS vector"))
+        Base.metadata.create_all(bind=engine)
+        _INITIALISED = True
+    except SQLAlchemyError as exc:
+        _LOGGER.error("Failed to initialise Postgres storage: %s", exc)
+
+
+@contextmanager
+def get_session() -> Iterator[Session]:
+    """Provide a transactional scope around a series of operations."""
+
+    if _SESSION_FACTORY is None and _get_engine() is None:
+        raise RuntimeError("Postgres session requested but POSTGRES_URL is not configured.")
+
+    session = _SESSION_FACTORY()
+    try:
+        yield session
+        session.commit()
+    except SQLAlchemyError as exc:
+        session.rollback()
+        _LOGGER.error("Postgres operation failed: %s", exc)
+        raise
+    finally:
+        session.close()
+
+
+def _preprocess_text(text: Optional[str]) -> Optional[str]:
+    if text is None:
+        return None
+    return " ".join(text.split()).lower()
+
+
+def store_processed_documents(collection_name: str, documents: Iterable[Document]) -> None:
+    """Persist processed document data and embeddings for backup."""
+
+    init_db()
+    if _SESSION_FACTORY is None:
+        return
+
+    with get_session() as session:
+        for document in documents:
+            embedding = None
+            if document.embedding is not None:
+                embedding_values = list(document.embedding)
+                if len(embedding_values) != EMBEDDING_DIMENSION:
+                    _LOGGER.warning(
+                        (
+                            "Document %s embedding has %d dimensions; expected %d. "
+                            "Embedding will be omitted from Postgres backup."
+                        ),
+                        document.id,
+                        len(embedding_values),
+                        EMBEDDING_DIMENSION,
+                    )
+                else:
+                    embedding = embedding_values
+            values = {
+                "collection_name": collection_name,
+                "text": document.text,
+                "preprocessed_text": _preprocess_text(document.text),
+                "metadata": document.metadata,
+                "metadata_labels": sorted(document.metadata.keys()) if document.metadata else None,
+                "embedding": embedding,
+            }
+            existing = session.get(ProcessedDocument, document.id)
+            if existing:
+                for field, value in values.items():
+                    setattr(existing, field, value)
+            else:
+                session.add(ProcessedDocument(id=document.id, **values))
+
+
+def remove_collection(collection_name: str) -> None:
+    """Delete all backups for ``collection_name``."""
+
+    init_db()
+    if _SESSION_FACTORY is None:
+        return
+
+    with get_session() as session:
+        session.execute(
+            delete(ProcessedDocument).where(ProcessedDocument.collection_name == collection_name)
+        )
+

--- a/app/routers/collections.py
+++ b/app/routers/collections.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter, HTTPException
 from typing import Optional
 from app.chroma_client import get_client
+from app.postgres_store import remove_collection
 
 router = APIRouter()
 
@@ -22,6 +23,7 @@ async def delete_collection(collection_name: str):
     try:
         client = get_client()
         client.delete_collection(name=collection_name)
+        remove_collection(collection_name)
         return {"message": f"Collection {collection_name} deleted successfully."}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -4,10 +4,16 @@ from fastapi import APIRouter, HTTPException, BackgroundTasks
 from typing import List
 from app.chroma_client import get_client
 from app.models import Document, Query
-from app.utils import get_openclip_embedding_function, get_image_loader
-from app.security import encrypt_data, decrypt_data
+from app.utils import (
+    build_chroma_fields,
+    get_image_loader,
+    get_openclip_embedding_function,
+)
+from app.postgres_store import store_processed_documents
+from app.security import decrypt_data
 import logging
 from datetime import datetime
+from app.metadata_enrichment import enrich_metadata, is_metadata_complete
 
 # Configure the logging
 logging.basicConfig(filename='audit.log', level=logging.INFO)
@@ -32,10 +38,15 @@ async def add_documents_task(collection_name: str, documents: List[Document]):
     client = get_client()
     collection = client.get_or_create_collection(name=collection_name)
 
+    for document in documents:
+        if not is_metadata_complete(document.metadata):
+            document.metadata = enrich_metadata(document)
+
     # Ensure that every field list has the same length as ``documents`` to
     # avoid errors in ChromaDB operations.
     fields = build_chroma_fields(documents)
     collection.add(**fields)
+    store_processed_documents(collection_name, documents)
 
 # Add documents to a collection (supports multimodal)
 @router.post("/add_documents/{collection_name}")
@@ -51,9 +62,14 @@ async def add_documents(collection_name: str, documents: List[Document]):
             data_loader=data_loader
         )
 
+        for document in documents:
+            if not is_metadata_complete(document.metadata):
+                document.metadata = enrich_metadata(document)
+
         # Store all fields with consistent lengths to avoid errors
         fields = build_chroma_fields(documents)
         collection.add(**fields)
+        store_processed_documents(collection_name, documents)
         return {"message": "Documents added successfully."}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
@@ -77,11 +93,16 @@ async def query_collection(collection_name: str, query: Query):
         )
 
         # Decrypt the metadata before returning
-        decrypted_metadata = [
-            decrypt_data(metadata)
-            for metadata in results['metadatas']
-        ]
-        results['metadatas'] = decrypted_metadata
+        if results.get("metadatas"):
+            results["metadatas"] = [
+                [
+                    decrypt_data(metadata)
+                    if metadata is not None
+                    else None
+                    for metadata in metadata_list
+                ]
+                for metadata_list in results["metadatas"]
+            ]
 
         return results
     except Exception as e:
@@ -100,15 +121,10 @@ async def update_documents(collection_name: str, documents: List[Document]):
         if len(existing_ids) != len(documents):
             raise HTTPException(status_code=400, detail="Some document IDs do not exist")
 
-        # Decrypt the existing metadata before performing updates
-        existing_metadata = [
-            decrypt_data(metadata) 
-            for metadata in collection.get(ids=existing_ids)['metadatas']
-        ]
-
         # Build field lists for the update, ensuring consistent lengths
         fields = build_chroma_fields(documents)
         collection.update(**fields)
+        store_processed_documents(collection_name, documents)
 
         # Log the update action for SOC 2 compliance
         for doc in documents:

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,10 +1,13 @@
 """Helper utilities used across the API."""
 
-from chromadb.utils.embedding_functions import OpenCLIPEmbeddingFunction
+import json
+from typing import Dict, List
+
 from chromadb.utils.data_loaders import ImageLoader
-from typing import List, Dict
-from models import Document
-from security import encrypt_data
+from chromadb.utils.embedding_functions import OpenCLIPEmbeddingFunction
+
+from app.models import Document
+from app.security import encrypt_data
 
 # Initialize the OpenCLIP embedding function
 def get_openclip_embedding_function() -> OpenCLIPEmbeddingFunction:
@@ -25,7 +28,9 @@ def build_chroma_fields(documents: List[Document]) -> Dict[str, List]:
         "ids": [doc.id for doc in documents],
         "documents": [doc.text for doc in documents],
         "metadatas": [
-            encrypt_data(str(doc.metadata)) if doc.metadata else None
+            encrypt_data(json.dumps(doc.metadata, sort_keys=True, ensure_ascii=False))
+            if doc.metadata
+            else None
             for doc in documents
         ],
         "embeddings": [doc.embedding for doc in documents],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,21 @@ services:
   chromadb:
     image: chromadb/chromadb:latest
     volumes:
-      - ./data/chromadb:/data
-    command: chroma run --path /data/chromadb
+      - ./data:/data
+    command: chroma run --path /data
     ports:
       - "8001:8000"
+
+  postgres:
+    image: ankane/pgvector:latest
+    environment:
+      POSTGRES_DB: chromarag
+      POSTGRES_USER: chroma
+      POSTGRES_PASSWORD: chroma-password
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
 
   fastapi:
     build: .
@@ -15,7 +26,12 @@ services:
       - "8000:8000"
     depends_on:
       - chromadb
+      - postgres
     volumes:
       - .:/app
     environment:
-      - DATABASE_URL=http://chromadb:8001
+      - DATABASE_URL=http://chromadb:8000
+      - POSTGRES_URL=postgresql+psycopg://chroma:chroma-password@postgres:5432/chromarag
+
+volumes:
+  postgres-data:

--- a/k8s/api.yaml
+++ b/k8s/api.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: chromarag-api
+  namespace: chromarag
+spec:
+  selector:
+    app: chromarag-api
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chromarag-api
+  namespace: chromarag
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: chromarag-api
+  template:
+    metadata:
+      labels:
+        app: chromarag-api
+    spec:
+      containers:
+        - name: chromarag-api
+          image: your-registry/chromarag:latest
+          imagePullPolicy: IfNotPresent
+          command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+          ports:
+            - containerPort: 8000
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: chromarag-config
+                  key: DATABASE_URL
+            - name: CHROMA_PERSIST_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: chromarag-config
+                  key: CHROMA_PERSIST_PATH
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: chromarag-postgres-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: chromarag-postgres-secret
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: chromarag-postgres-secret
+                  key: POSTGRES_DB
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: chromarag-postgres-secret
+                  key: POSTGRES_HOST
+            - name: POSTGRES_URL
+              value: postgresql+psycopg://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST):5432/$(POSTGRES_DB)
+          readinessProbe:
+            httpGet:
+              path: /docs
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /docs
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/k8s/chromadb.yaml
+++ b/k8s/chromadb.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: chromadb-data
+  namespace: chromarag
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: chromadb
+  namespace: chromarag
+spec:
+  selector:
+    app: chromadb
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chromadb
+  namespace: chromarag
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: chromadb
+  template:
+    metadata:
+      labels:
+        app: chromadb
+    spec:
+      containers:
+        - name: chromadb
+          image: chromadb/chromadb:latest
+          args: ["chroma", "run", "--path", "/data"]
+          ports:
+            - containerPort: 8000
+          volumeMounts:
+            - name: chromadb-storage
+              mountPath: /data
+      volumes:
+        - name: chromadb-storage
+          persistentVolumeClaim:
+            claimName: chromadb-data

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chromarag-config
+  namespace: chromarag
+data:
+  DATABASE_URL: http://chromadb.chromarag.svc.cluster.local:8000
+  CHROMA_PERSIST_PATH: /data

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chromarag

--- a/k8s/postgres.yaml
+++ b/k8s/postgres.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: chromarag
+spec:
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+  clusterIP: None
+  selector:
+    app: postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: chromarag
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: ankane/pgvector:latest
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: chromarag-postgres-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: chromarag-postgres-secret
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: chromarag-postgres-secret
+                  key: POSTGRES_DB
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+      terminationGracePeriodSeconds: 30
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 20Gi

--- a/k8s/secrets.example.yaml
+++ b/k8s/secrets.example.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chromarag-postgres-secret
+  namespace: chromarag
+type: Opaque
+stringData:
+  POSTGRES_USER: chroma
+  POSTGRES_PASSWORD: change-me
+  POSTGRES_DB: chromarag
+  POSTGRES_HOST: postgres.chromarag.svc.cluster.local

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,39 @@
+services:
+  - type: web
+    name: chromarag-api
+    env: docker
+    plan: starter
+    dockerfilePath: ./Dockerfile
+    autoDeploy: true
+    envVars:
+      - key: DATABASE_URL
+        value: http://chromarag-chromadb:8000
+      - key: POSTGRES_URL
+        fromDatabase:
+          name: chromarag-postgres
+          property: connectionString
+    dependsOn:
+      - chromarag-chromadb
+  - type: privateService
+    name: chromarag-chromadb
+    env: docker
+    plan: starter
+    image: chromadb/chromadb:latest
+    startCommand: chroma run --path /data
+    autoDeploy: true
+    envVars:
+      - key: CHROMA_SERVER_HOST
+        value: 0.0.0.0
+      - key: CHROMA_SERVER_HTTP_PORT
+        value: "8000"
+    disk:
+      name: chroma-data
+      mountPath: /data
+      sizeGB: 10
+
+databases:
+  - name: chromarag-postgres
+    plan: starter
+    databaseName: chromarag
+    user: chroma
+    ipAllowList: []

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,9 @@ cryptography==43.0.0
 asyncio==3.4.3
 starlette==0.38.2
 mcp[cli]
+numpy==1.26.4
+sqlalchemy==2.0.31
+psycopg[binary]==3.2.1
+pgvector==0.2.5
+pypdf==4.2.0
+requests==2.32.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_metadata_enrichment.py
+++ b/tests/test_metadata_enrichment.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+from pypdf import PdfWriter
+
+from app.metadata_enrichment import enrich_metadata, is_metadata_complete
+from app.models import Document
+
+
+def _create_pdf(tmp_path: Path) -> Path:
+    pdf_path = tmp_path / "sample.pdf"
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.add_metadata(
+        {
+            "/Title": "Sample PDF",
+            "/Author": "Jane Doe",
+            "/Subject": "Demonstration",
+            "/CreationDate": "D:20240101000000Z",
+        }
+    )
+    with pdf_path.open("wb") as file:
+        writer.write(file)
+    return pdf_path
+
+
+def test_enrich_metadata_extracts_pdf_fields(tmp_path):
+    pdf_path = _create_pdf(tmp_path)
+    document = Document(
+        id="doc-1",
+        text="This document describes compliance processes and audit readiness.",
+        metadata={"file_path": str(pdf_path)},
+    )
+
+    metadata = enrich_metadata(document)
+
+    assert metadata["title"] == "Sample PDF"
+    assert metadata["author"] == "Jane Doe"
+    assert metadata["subject"] == "Demonstration"
+    assert metadata["created_at"].startswith("2024-01-01")
+    assert "summary" in metadata and metadata["summary"]
+    assert is_metadata_complete(metadata)
+
+
+def test_enrich_metadata_generates_keywords_and_topics():
+    text = (
+        "Artificial intelligence streamlines compliance workflows. "
+        "Natural language processing highlights regulatory obligations. "
+        "Embedding backups ensure resilient retrieval operations."
+    )
+    document = Document(id="doc-2", text=text)
+
+    metadata = enrich_metadata(document)
+
+    assert metadata["summary"].startswith("Artificial intelligence streamlines")
+    assert "artificial" in metadata["keywords"]
+    assert isinstance(metadata["topics"], list) and metadata["topics"]
+    assert metadata["topics"][0] in metadata["keywords"]
+
+
+def test_enrich_metadata_overwrites_blank_fields():
+    text = "Automation improves compliance posture and reduces manual review overhead."
+    document = Document(
+        id="doc-blank",
+        text=text,
+        metadata={"summary": "", "topics": [], "keywords": []},
+    )
+
+    metadata = enrich_metadata(document)
+
+    assert metadata["summary"].startswith("Automation improves compliance posture")
+    assert metadata["topics"]
+    assert metadata["keywords"]
+    assert is_metadata_complete(metadata)
+
+
+def test_enrich_metadata_handles_llm_absence(monkeypatch):
+    monkeypatch.setenv("METADATA_LLM_API_KEY", "test-key")
+    document = Document(
+        id="doc-3",
+        text="Data governance policies guide secure document processing.",
+    )
+
+    metadata = enrich_metadata(document)
+
+    assert metadata["summary"].startswith("Data governance policies")
+    assert "governance" in metadata["keywords"]
+
+    monkeypatch.delenv("METADATA_LLM_API_KEY")


### PR DESCRIPTION
## Summary
- specify the pgvector column dimension from configuration and ignore mismatched embeddings when backing up documents
- treat empty or placeholder metadata values as incomplete, adding fallback titles and overwriting blanks during enrichment
- extend metadata enrichment tests to cover blank metadata scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d86f79fc3083339bf1c751c6c1c649